### PR TITLE
Introduce `PublicItem` to the public API

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,13 @@ jobs:
     - uses: actions/checkout@v2
     - run: cargo fmt -- --check
 
+  cargo-doc:
+    name: RUSTDOCFLAGS='-D warnings' cargo doc
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: RUSTDOCFLAGS='-D warnings' cargo doc
+
   cargo-clippy:
     name: cargo clippy -- -D clippy::all -D clippy::pedantic
     runs-on: ubuntu-latest

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cargo",
+			"command": "build",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": "build",
+			"label": "rust: cargo build"
+		},
+		{
+			"type": "cargo",
+			"command": "test",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": "build",
+			"label": "rust: cargo test"
+		},
+		{
+			"type": "cargo",
+			"command": "check",
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": "build",
+			"label": "rust: cargo check"
+		},
+		{
+			"type": "cargo",
+			"command": "clippy",
+			"args": [
+				"--all-targets",
+				"--all-features",
+				"--",
+				"-D",
+				"clippy::all",
+				"-D",
+				"clippy::pedantic"
+			],
+			"problemMatcher": [
+				"$rustc"
+			],
+			"group": "build",
+			"label": "rust: cargo clippy"
+		},
+	]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,67 @@
 mod error;
+mod implementation;
+
+/// Enumerates all errors that can occur within this crate.
 pub use error::Error;
+
+/// Shorthand for [`std::result::Result<T, crate::Error>`].
 pub use error::Result;
 
-mod implementation;
-pub use implementation::sorted_public_items_from_rustdoc_json_str;
+/// Represent a public item of an analyzed crate, i.e. an item that forms part
+/// of the public API of a crate. Implements `Display` so it can be printed. It
+/// also implements [`Ord`], but how items are ordered are not stable yet, and
+/// will change in later versions.
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct PublicItem {
+    /// Private implementation detail. The "pub struct/fn/..." part of an item.
+    prefix: String,
+
+    /// Private implementation detail. The "your_crate::mod_a::mod_b" part of an
+    /// item.
+    path: String,
+
+    /// Private implementation detail. The type info part, e.g. "(param_a: Type,
+    /// param_b: OtherType)" for a `fn`.
+    suffix: String,
+}
+
+/// Takes rustdoc JSON and returns a [`Vec`] of [`PublicItem`]s where each
+/// [`PublicItem`] is one public item of the crate, i.e. part of the crate's
+/// public API. The [`Vec`] is sorted in a way suitable for display to humans,
+/// but the exact order is unspecified.
+///
+/// There exists a convenient `cargo` wrapper for this function found at
+/// <https://github.com/Enselic/cargo-public-items> that builds the rustdoc JSON
+/// for you and then invokes this function. If you don't want to use that
+/// wrapper, use
+/// ```bash
+/// RUSTDOCFLAGS='-Z unstable-options --output-format json' cargo +nightly doc --lib --no-deps
+/// ```
+/// to generate the rustdoc JSON that this function takes as input. For
+/// reference, the rustdoc JSON format is documented at
+/// <https://rust-lang.github.io/rfcs/2963-rustdoc-json.html>. Open PRs and
+/// issues for rustdoc JSON itself can be found at
+/// <https://github.com/rust-lang/rust/labels/A-rustdoc-json>.
+///
+/// # Errors
+///
+/// E.g. if the JSON is invalid.
+pub fn sorted_public_items_from_rustdoc_json_str(
+    rustdoc_json_str: &str,
+) -> Result<Vec<PublicItem>> {
+    let crate_: rustdoc_types::Crate = serde_json::from_str(rustdoc_json_str)?;
+
+    let mut v: Vec<PublicItem> = implementation::public_items_in_crate(&crate_).collect();
+
+    v.sort();
+
+    Ok(v)
+}
+
+/// One of the basic uses cases is printing a sorted `Vec` of `PublicItem`s. So
+/// we implement `Display` for it.
+impl std::fmt::Display for PublicItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}{}", self.prefix, self.path, self.suffix)
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17,7 +17,12 @@ fn thiserror_v1_0_30() {
 }
 
 fn assert_public_items(rustdoc_json_str: &str, expected_output: &str) {
-    let actual = public_items::sorted_public_items_from_rustdoc_json_str(rustdoc_json_str).unwrap();
+    let actual: Vec<String> =
+        public_items::sorted_public_items_from_rustdoc_json_str(rustdoc_json_str)
+            .unwrap()
+            .into_iter()
+            .map(|x| format!("{}", x))
+            .collect();
 
     let expected = expected_output_to_string_vec(expected_output);
 

--- a/tests/rustdoc_json/bless.sh
+++ b/tests/rustdoc_json/bless.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit
+
+base="tests/rustdoc_json"
+
+for input in syntect-v4.6.0 thiserror-v1.0.30; do
+    printf "%s" "$(cargo run ${base}/${input}_FORMAT_VERSION_10.json)" > "${base}/${input}-expected.txt"
+done

--- a/tests/rustdoc_json/syntect-v4.6.0-expected.txt
+++ b/tests/rustdoc_json/syntect-v4.6.0-expected.txt
@@ -906,6 +906,42 @@ pub mod syntect::html
 pub mod syntect::parsing
 pub mod syntect::parsing::syntax_definition
 pub mod syntect::util
+pub struct syntect::easy::HighlightFile<'a>
+pub struct syntect::easy::HighlightLines<'a>
+pub struct syntect::easy::ScopeRegionIterator<'a>
+pub struct syntect::highlighting::Color
+pub struct syntect::highlighting::FontStyle
+pub struct syntect::highlighting::HighlightIterator<'a, 'b>
+pub struct syntect::highlighting::HighlightState
+pub struct syntect::highlighting::Highlighter<'a>
+pub struct syntect::highlighting::RangedHighlightIterator<'a, 'b>
+pub struct syntect::highlighting::ScopeSelector
+pub struct syntect::highlighting::ScopeSelectors
+pub struct syntect::highlighting::ScoredStyle
+pub struct syntect::highlighting::Style
+pub struct syntect::highlighting::StyleModifier
+pub struct syntect::highlighting::Theme
+pub struct syntect::highlighting::ThemeItem
+pub struct syntect::highlighting::ThemeSet
+pub struct syntect::highlighting::ThemeSettings
+pub struct syntect::html::ClassedHTMLGenerator<'a>
+pub struct syntect::parsing::MatchPower
+pub struct syntect::parsing::ParseState
+pub struct syntect::parsing::Regex
+pub struct syntect::parsing::Region
+pub struct syntect::parsing::SCOPE_REPO
+pub struct syntect::parsing::Scope
+pub struct syntect::parsing::ScopeRepository
+pub struct syntect::parsing::ScopeStack
+pub struct syntect::parsing::SyntaxReference
+pub struct syntect::parsing::SyntaxSet
+pub struct syntect::parsing::SyntaxSetBuilder
+pub struct syntect::parsing::syntax_definition::Context
+pub struct syntect::parsing::syntax_definition::ContextId
+pub struct syntect::parsing::syntax_definition::MatchIter<'a>
+pub struct syntect::parsing::syntax_definition::MatchPattern
+pub struct syntect::parsing::syntax_definition::SyntaxDefinition
+pub struct syntect::util::LinesWithEndings<'a>
 pub struct field syntect::easy::HighlightFile::highlight_lines: HighlightLines<'a>
 pub struct field syntect::easy::HighlightFile::reader: BufReader<File>
 pub struct field syntect::highlighting::Color::a: u8
@@ -997,42 +1033,6 @@ pub struct field syntect::parsing::syntax_definition::SyntaxDefinition::hidden: 
 pub struct field syntect::parsing::syntax_definition::SyntaxDefinition::name: String
 pub struct field syntect::parsing::syntax_definition::SyntaxDefinition::scope: Scope
 pub struct field syntect::parsing::syntax_definition::SyntaxDefinition::variables: HashMap<String, String>
-pub struct syntect::easy::HighlightFile<'a>
-pub struct syntect::easy::HighlightLines<'a>
-pub struct syntect::easy::ScopeRegionIterator<'a>
-pub struct syntect::highlighting::Color
-pub struct syntect::highlighting::FontStyle
-pub struct syntect::highlighting::HighlightIterator<'a, 'b>
-pub struct syntect::highlighting::HighlightState
-pub struct syntect::highlighting::Highlighter<'a>
-pub struct syntect::highlighting::RangedHighlightIterator<'a, 'b>
-pub struct syntect::highlighting::ScopeSelector
-pub struct syntect::highlighting::ScopeSelectors
-pub struct syntect::highlighting::ScoredStyle
-pub struct syntect::highlighting::Style
-pub struct syntect::highlighting::StyleModifier
-pub struct syntect::highlighting::Theme
-pub struct syntect::highlighting::ThemeItem
-pub struct syntect::highlighting::ThemeSet
-pub struct syntect::highlighting::ThemeSettings
-pub struct syntect::html::ClassedHTMLGenerator<'a>
-pub struct syntect::parsing::MatchPower
-pub struct syntect::parsing::ParseState
-pub struct syntect::parsing::Regex
-pub struct syntect::parsing::Region
-pub struct syntect::parsing::SCOPE_REPO
-pub struct syntect::parsing::Scope
-pub struct syntect::parsing::ScopeRepository
-pub struct syntect::parsing::ScopeStack
-pub struct syntect::parsing::SyntaxReference
-pub struct syntect::parsing::SyntaxSet
-pub struct syntect::parsing::SyntaxSetBuilder
-pub struct syntect::parsing::syntax_definition::Context
-pub struct syntect::parsing::syntax_definition::ContextId
-pub struct syntect::parsing::syntax_definition::MatchIter<'a>
-pub struct syntect::parsing::syntax_definition::MatchPattern
-pub struct syntect::parsing::syntax_definition::SyntaxDefinition
-pub struct syntect::util::LinesWithEndings<'a>
 pub type syntect::LoadingError::Error = <U as TryFrom<T>>::Error
 pub type syntect::LoadingError::Error = Infallible
 pub type syntect::easy::HighlightFile::Error = <U as TryFrom<T>>::Error


### PR DESCRIPTION
This will allow us to later support more clever sorting/grouping of
public items. E.g. struct fields shall come directly after their
containing struct.

See related discussion in Enselic/cargo-public-api#43