### PR TITLE
render_generic_param_def(): Use proper token for name

### DIFF
--- a/scripts/bless-expected-output-for-tests.sh
+++ b/scripts/bless-expected-output-for-tests.sh
@@ -15,4 +15,4 @@ for crate in ${crates}; do
 done
 
 cargo run -- --with-blanket-implementations "./tests/rustdoc-json/example_api-v0.2.0.json" > \
-      "${dst}/eample_api-v0.2.0-with-blanket-implementations.txt"
+      "${dst}/example_api-v0.2.0-with-blanket-implementations.txt"


### PR DESCRIPTION
    By inlining render_generic() and using Token::lifetime() for lifetime,
    etc.
