### PR TITLE
CI: Remove code coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,16 +48,3 @@ jobs:
         toolchain: nightly
         profile: minimal
     - run: cargo test
-
-  code-coverage:
-    name: code coverage
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        profile: minimal
-        components: llvm-tools-preview
-    - run: cargo install cargo-llvm-cov
-    - run: cargo +nightly llvm-cov


### PR DESCRIPTION
Takes too long to run and can easily and more appropriately be run
locally. This is the command I use:

    cargo llvm-cov --html && open target/llvm-cov/html/index.html