### PR TITLE
doc/development.md: Give code coverage tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,7 @@ labeled issues.
 | v0.5.x        | nightly-2022-02-23 — nightly-2022-03-13 |
 | v0.2.x        | nightly-2022-01-19 — nightly-2022-02-22 |
 | v0.0.5        | nightly-2021-10-11 — nightly-2022-01-18 |
+
+# Development
+
+See [development.md](./doc/development.md).

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,0 +1,9 @@
+# Code coverage
+
+Exploring code coverage is a good way to ensure we have broad enough tests. This is the command I use personally to get started:
+
+```bash
+cargo llvm-cov --html && open target/llvm-cov/html/index.html
+```
+
+Which obviously requires you to have done `cargo install cargo-llvm-cov` first.


### PR DESCRIPTION
Now that CI does not show what command to use any longe (see https://github.com/Enselic/public-api/pull/76)