### PR TITLE
render_path(): Make Token::Type part of the path

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -169,6 +169,15 @@ fn render_path(path: &[Rc<IntermediatePublicItem<'_>>]) -> TokenStream {
     for item in path {
         let token_fn = if matches!(item.item.inner, ItemEnum::Function(_) | ItemEnum::Method(_)) {
             Token::function
+        } else if matches!(
+            item.item.inner,
+            ItemEnum::Trait(_)
+                | ItemEnum::Struct(_)
+                | ItemEnum::Union(_)
+                | ItemEnum::Enum(_)
+                | ItemEnum::Typedef(_)
+        ) {
+            Token::type_
         } else {
             Token::identifier
         };


### PR DESCRIPTION
So that we can colorize types also when part of a path, and not only
when part of a function argument or a struct field.