### PR TITLE
CI: Ensure Cargo.lock is up to date by using --locked

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: RUSTDOCFLAGS='-D warnings' cargo doc --no-deps
+    - run: RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps
 
   cargo-clippy:
     name: cargo clippy -- -D clippy::all -D clippy::pedantic
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: cargo clippy --all-targets --all-features -- -D clippy::all -D clippy::pedantic
+    - run: cargo clippy --locked --all-targets --all-features -- -D clippy::all -D clippy::pedantic
 
   cargo-test:
     name: cargo test
@@ -47,4 +47,4 @@ jobs:
       with:
         toolchain: nightly
         profile: minimal
-    - run: cargo test
+    - run: cargo test --locked

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -7,6 +7,6 @@ set -o nounset -o pipefail -o errexit -o xtrace
 
 # CI.yml
 cargo fmt -- --check
-RUSTDOCFLAGS='-D warnings' cargo doc --no-deps
-cargo clippy --all-targets --all-features -- -D clippy::all -D clippy::pedantic
-cargo test
+RUSTDOCFLAGS='-D warnings' cargo doc  --locked --no-deps
+cargo clippy --locked --all-targets --all-features -- -D clippy::all -D clippy::pedantic
+cargo test --locked


### PR DESCRIPTION
Otherwise CI will not fail if you e.g. update version in Cargo.toml but
forget to update Cargo.toml. We want CI to fail in that case.