### PR TITLE
Add infrastructure to allow dry-running making a release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_call: # From .github/workflows/release.yml
   workflow_dispatch:
   push:
     branches: [ main ]

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify:
+    uses: .github/workflows/CI.yml
+
+  release:
+    needs: verify
+    environment: cargo-publish
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: ./scripts/release.sh

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit -o xtrace
+
+# First, deploy
+cargo publish --dry-run
+
+# If that was successful, push a git tag that matches Cargo.toml version
+pyjq() {
+    python3 -c "import json, sys; print(json.load(sys.stdin)${1})"
+}
+version=$(cargo read-manifest | pyjq '["version"]')
+version_tag="v${version}"
+echo git tag "${version_tag}"
+echo git push origin "${version_tag}"
+
+# Done!


### PR DESCRIPTION
If this works out, I will remove the dry-run code and make releases for
real through GitHub Actions. I need to merge this first to be able to do some experimentation though.