### PR TITLE
Properly render HRTBs for GenericBound::TraitBound

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -656,8 +656,13 @@ fn render_generic_bounds(root: &Crate, bounds: &[GenericBound]) -> Vec<Token> {
                     generic_params,
                     ..
                 } => {
-                    let mut output = render_type(root, trait_);
-                    output.extend(render_generic_param_defs(root, generic_params));
+                    let mut output = vec![];
+                    if !generic_params.is_empty() {
+                        output.push(Token::keyword("for"));
+                        output.extend(render_generic_param_defs(root, generic_params));
+                        output.push(ws!());
+                    }
+                    output.extend(render_type(root, trait_));
                     output
                 }
                 GenericBound::Outlives(id) => vec![Token::lifetime(id)],

--- a/tests/crates/comprehensive_api/src/higher_ranked_trait_bounds.rs
+++ b/tests/crates/comprehensive_api/src/higher_ranked_trait_bounds.rs
@@ -1,0 +1,31 @@
+// The contents of this file is a partial copy of
+// https://github.com/rust-lang/rust/blob/508e0584e384556b7e66f57b62e4feeba864b6da/src/test/rustdoc/higher-ranked-trait-bounds.rs
+// which is licensed under
+// https://github.com/rust-lang/rust/blob/master/LICENSE-MIT. The license is as
+// follows:
+//
+//   Permission is hereby granted, free of charge, to any person obtaining a copy
+//   of this software and associated documentation files (the "Software"), to deal
+//   in the Software without restriction, including without limitation the rights
+//   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//   copies of the Software, and to permit persons to whom the Software is
+//   furnished to do so, subject to the following conditions:
+//
+//   The above copyright notice and this permission notice shall be included in
+//   all copies or substantial portions of the Software.
+//
+//   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//   SOFTWARE.
+
+// @has foo/fn.test3.html
+// @has - '//pre' "pub fn test3<F>() where F: for<'a, 'b> Fn(&'a u8, &'b u8),"
+pub fn test3<F>()
+where
+    F: for<'a, 'b> Fn(&'a u8, &'b u8),
+{
+}

--- a/tests/crates/comprehensive_api/src/lib.rs
+++ b/tests/crates/comprehensive_api/src/lib.rs
@@ -10,6 +10,7 @@ mod private;
 pub mod constants;
 pub mod enums;
 pub mod functions;
+pub mod higher_ranked_trait_bounds;
 pub mod impls;
 pub mod macros;
 pub mod statics;

--- a/tests/expected-output/comprehensive_api.txt
+++ b/tests/expected-output/comprehensive_api.txt
@@ -37,6 +37,7 @@ pub fn comprehensive_api::functions::return_tuple() -> (bool, Basic)
 pub fn comprehensive_api::functions::somewhere<T, U>(t: T, u: U) where T: Display, U: Debug
 pub fn comprehensive_api::functions::struct_arg(s: PrivateField)
 pub fn comprehensive_api::functions::synthetic_arg(t: impl Simple) -> impl Simple
+pub fn comprehensive_api::higher_ranked_trait_bounds::test3<F>() where F: for<'a, 'b> Fn(&'a u8, &'b u8)
 pub fn comprehensive_api::structs::Plain::f()
 pub fn comprehensive_api::structs::Plain::new() -> Plain
 pub fn comprehensive_api::structs::Plain::s1(self)
@@ -50,6 +51,7 @@ pub mod comprehensive_api
 pub mod comprehensive_api::constants
 pub mod comprehensive_api::enums
 pub mod comprehensive_api::functions
+pub mod comprehensive_api::higher_ranked_trait_bounds
 pub mod comprehensive_api::impls
 pub mod comprehensive_api::macros
 pub mod comprehensive_api::statics


### PR DESCRIPTION
The rustdoc HTML looks like this:

    pub fn test3<F>()
    where
        F: for<'a, 'b> Fn(&'a u8, &'b u8),

and with this fix, our output looks like this:

    pub fn comprehensive_api::higher_ranked_trait_bounds::test3<F>() where F: for<'a, 'b> Fn(&'a u8, &'b u8)

normalizing and putting them next to each other, we can see that we now
render correctly in this case:

    pub fn                                                test3<F>() where F: for<'a, 'b> Fn(&'a u8, &'b u8),
    pub fn comprehensive_api::higher_ranked_trait_bounds::test3<F>() where F: for<'a, 'b> Fn(&'a u8, &'b u8)

This is part of fixing #88.